### PR TITLE
Make notifications queueable

### DIFF
--- a/src/Notifications/Unsubscribed.php
+++ b/src/Notifications/Unsubscribed.php
@@ -2,11 +2,15 @@
 
 namespace Biigle\Modules\Newsletter\Notifications;
 
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class Unsubscribed extends Notification
+class Unsubscribed extends Notification implements ShouldQueue
 {
+    use Queueable;
+
     /**
      * Get the notification's delivery channels.
      *

--- a/src/Notifications/VerifyEmail.php
+++ b/src/Notifications/VerifyEmail.php
@@ -4,11 +4,15 @@ namespace Biigle\Modules\Newsletter\Notifications;
 
 use Carbon\Carbon;
 use Illuminate\Auth\Notifications\VerifyEmail as Base;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use URL;
 
-class VerifyEmail extends Base
+class VerifyEmail extends Base implements ShouldQueue
 {
+    use Queueable;
+
     /**
      * Get the verify email notification mail message for the given URL.
      *


### PR DESCRIPTION
The VerifyEmail notification is hooked up into the registration workflow. If this notification fails, the registration fails. Now the notification is queued and won't make the registration fail. Instead, the notification may be retried on the queue.